### PR TITLE
Implement handshake and login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2683,6 +2684,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "v_frame"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ byteorder = "1.5.0"
 bytes = "1.9.0"
 image = "0.25.5"
 base64 = "0.22.1"
+uuid = { version = "1", features = ["v4"] }
 
 
 [profile.release]


### PR DESCRIPTION
## Summary
- support handshake parsing and state switching
- implement offline login with Login Success response
- add `uuid` dependency for generating fallback UUIDs

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683ff6a25d18832e9d3cd372995c9d00