### PR TITLE
Implement handshake and login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2683,6 +2684,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "v_frame"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ byteorder = "1.5.0"
 bytes = "1.9.0"
 image = "0.25.5"
 base64 = "0.22.1"
+uuid = { version = "1", features = ["v4"] }
 
 
 [profile.release]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -154,7 +154,7 @@ async fn handle_packet(conn: &Connection, packet: Packet) -> Result<Response, Ne
 
     // Dispatch packet depending on the current State.
     match conn.get_state().await {
-        ConnectionState::Handshake => dispatch::handshake(conn).await,
+        ConnectionState::Handshake => dispatch::handshake(conn, packet).await,
         ConnectionState::Status => dispatch::status(packet).await,
         ConnectionState::Login => dispatch::login(conn, packet).await,
         ConnectionState::Transfer => dispatch::transfer(conn, packet).await,
@@ -163,11 +163,48 @@ async fn handle_packet(conn: &Connection, packet: Packet) -> Result<Response, Ne
 
 mod dispatch {
     use super::*;
-    use packet::Response;
+    use byteorder::{BigEndian, ByteOrder};
+    use packet::{self, Response};
+    use uuid::Uuid;
+    use crate::player;
 
-    pub async fn handshake(conn: &Connection) -> Result<Response, NetError> {
-        // Set state to Status
-        conn.set_state(ConnectionState::Status).await;
+    pub async fn handshake(conn: &Connection, packet: Packet) -> Result<Response, NetError> {
+        if packet.get_id().get_value() != 0x00 {
+            return Err(NetError::UnknownPacketId(format!(
+                "unknown packet ID, State: Handshake, PacketId: {}",
+                packet.get_id().get_value()
+            )));
+        }
+
+        let data = packet.get_payload();
+        let (protocol_version, mut index) = packet::data_types::varint::read(data)
+            .map_err(|e| NetError::Parsing(packet::PacketError::PayloadDecodeError(e.to_string())))?;
+
+        let (_address, read) = packet::data_types::string::read(&data[index..])
+            .map_err(|e| NetError::Parsing(packet::PacketError::PayloadDecodeError(e.to_string())))?;
+        index += read;
+
+        if index + 2 > data.len() {
+            return Err(NetError::Parsing(packet::PacketError::PayloadDecodeError(
+                "Invalid handshake port".into(),
+            )));
+        }
+        let _port = BigEndian::read_u16(&data[index..index + 2]);
+        index += 2;
+
+        let (next_state, _) = packet::data_types::varint::read(&data[index..])
+            .map_err(|e| NetError::Parsing(packet::PacketError::PayloadDecodeError(e.to_string())))?;
+
+        match next_state {
+            1 => conn.set_state(ConnectionState::Status).await,
+            2 => conn.set_state(ConnectionState::Login).await,
+            _ => conn.set_state(ConnectionState::Status).await,
+        }
+
+        debug!(
+            "Handshake with protocol {protocol_version}, moving to state {:?}",
+            conn.get_state().await
+        );
 
         Ok(Response::new(None))
     }
@@ -203,10 +240,52 @@ mod dispatch {
     }
 
     pub async fn login(conn: &Connection, packet: Packet) -> Result<Response, NetError> {
-        todo!()
+        if packet.get_id().get_value() != 0x00 {
+            return Err(NetError::UnknownPacketId(format!(
+                "unknown packet ID, State: Login, PacketId: {}",
+                packet.get_id().get_value()
+            )));
+        }
+
+        let data = packet.get_payload();
+        let (username, _idx) = packet::data_types::string::read(data)
+            .map_err(|e| NetError::Parsing(packet::PacketError::PayloadDecodeError(e.to_string())))?;
+
+        let uuid_str = match player::get_uuid(&username).await {
+            Ok(id) => id,
+            Err(_) => Uuid::new_v4().simple().to_string(),
+        };
+
+        let uuid = Uuid::parse_str(&uuid_str).unwrap_or_else(|_| Uuid::new_v4());
+
+        let mut builder = packet::PacketBuilder::new();
+        builder
+            .append_bytes(uuid.as_bytes())
+            .append_string(&username);
+
+        let login_success = builder.build(0x02)?;
+
+        conn.set_state(ConnectionState::Transfer).await;
+
+        Ok(Response::new(Some(login_success)))
     }
 
     pub async fn transfer(conn: &Connection, packet: Packet) -> Result<Response, NetError> {
-        todo!()
+        if packet.get_id().get_value() != 0x00 {
+            return Err(NetError::UnknownPacketId(format!(
+                "unknown packet ID, State: Transfer, PacketId: {}",
+                packet.get_id().get_value()
+            )));
+        }
+
+        if !packet.get_payload().is_empty() {
+            return Err(NetError::Parsing(packet::PacketError::PayloadDecodeError(
+                "Login Finished packet should not contain data".into(),
+            )));
+        }
+
+        debug!("Received Login Finished, login sequence completed");
+
+        Ok(Response::new(None))
     }
 }


### PR DESCRIPTION
## Summary
- support handshake parsing and state switching
- implement offline login with Login Success response
- add `uuid` dependency for generating fallback UUIDs
- fix login success packet to send raw UUID bytes

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683ff6a25d18832e9d3cd372995c9d00